### PR TITLE
read config file earlier

### DIFF
--- a/de.dentrassi.pm.root.feature/root/server
+++ b/de.dentrassi.pm.root.feature/root/server
@@ -2,6 +2,8 @@
 
 DIR=$(cd $(dirname "$0"); pwd)
 
+test -f /etc/default/package-drone-server && . /etc/default/package-drone-server
+
 JAVA="java"
 
 if [ -n "$JAVA_HOME" ]; then
@@ -10,8 +12,6 @@ fi
 
 echo "Using Java: $JAVA"
 echo "   Options: $JAVA_OPTS"
-
-test -f /etc/default/package-drone-server && . /etc/default/package-drone-server
 
 if [ -n "$PIDFILE" ]; then
     echo $$ > "$PIDFILE"


### PR DESCRIPTION
We should read the configuration file as early as possible.
So you could set the java options and runtime environment in the configuration file.

Without this change the logged information (using java; options) could differ from the used one.