### PR TITLE
Support gradle snapshot uploads

### DIFF
--- a/de.dentrassi.pm.maven/src/de/dentrassi/pm/maven/internal/MavenServlet.java
+++ b/de.dentrassi.pm.maven/src/de/dentrassi/pm/maven/internal/MavenServlet.java
@@ -474,6 +474,29 @@ public class MavenServlet extends AbstractStorageServiceServlet
                     }
                 }
 
+                if (plain.isEmpty() && classified.isEmpty()) 
+                {
+                    // no upload will happen in this case - maybe we should make up
+                    // some information based on what we do know, presuming that this
+                    // metadata describes a single snapshot jar artifact.
+                    final MavenInformation synthetic = new MavenInformation ();
+                    info.setGroupId ( groupId );
+                    info.setArtifactId ( artifactId );
+                    info.setVersion ( version );
+                    
+                    // let us not set a classifier and assume it is a jar
+                    info.setExtension("jar");
+                    // this should be something like 1.2.3-120398120398.129837192387
+                    info.setSnapshotVersion(
+                        String.format("%s-%s-%s",
+                            version.substring(0, version.length() - "SNAPSHOT".length()),
+                            snapshotTimestamp,
+                            snapshotBuildNumber));
+                    info.setBuildNumber(snapshotBuildNumber);
+                    
+                    plain.add(info);
+                }
+
                 store ( channel, plain, classified );
             }
         }

--- a/de.dentrassi.pm.maven/src/de/dentrassi/pm/maven/internal/MavenServlet.java
+++ b/de.dentrassi.pm.maven/src/de/dentrassi/pm/maven/internal/MavenServlet.java
@@ -479,7 +479,7 @@ public class MavenServlet extends AbstractStorageServiceServlet
                     // no upload will happen in this case - maybe we should make up
                     // some information based on what we do know, presuming that this
                     // metadata describes a single snapshot jar artifact.
-                    final MavenInformation synthetic = new MavenInformation ();
+                    final MavenInformation info = new MavenInformation ();
                     info.setGroupId ( groupId );
                     info.setArtifactId ( artifactId );
                     info.setVersion ( version );


### PR DESCRIPTION
Gradle snapshots seem to produce maven-metadata like this:

``` xml
<?xml version="1.0" encoding="UTF-8" standalone="no"?>
<metadata>
  <groupId>uk.org.cse.nhm</groupId>
  <artifactId>bundle-impl</artifactId>
  <version>6.2.0-SNAPSHOT</version>
  <versioning>
    <snapshot>
      <timestamp>20150812.163518</timestamp>
      <buildNumber>1</buildNumber>
    </snapshot>
    <lastUpdated>20150812163518</lastUpdated>
  </versioning>
</metadata>
```

which lacks the snapshotVersion that maven produces. This change presumes a single jar artifact in the event that no snapshot version metadata is generated.

See #61.
